### PR TITLE
Fixed GetArticle API call.

### DIFF
--- a/articles.go
+++ b/articles.go
@@ -7,9 +7,9 @@ import (
 
 // GetArticle returns an article with post content for the provided article id.
 // https://docs.dev.to/api/#tag/articles/paths/~1articles~1{id}/get
-func (c *Client) GetArticle(id string) (*Article, error) {
+func (c *Client) GetArticle(id int32) (*Article, error) {
 	var res Article
-	err := c.get(c.baseURL+fmt.Sprintf("/article/%s", id), &res)
+	err := c.get(c.baseURL+fmt.Sprintf("/articles/%d", id), &res)
 
 	return &res, err
 }


### PR DESCRIPTION
- Made changes to the API endpoint `https://dev.to/api/articles/{id}` to `https://dev.to/api/article/{id}`

- Changed the type of `id` from `string` to `int32` based on API documentation.
 